### PR TITLE
Fix #21

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -72,7 +72,7 @@ function bodyPath(el, path) {
 
 function grabUrls() {
   var urls = hyperize(true);
-  DocumentApp.getUi().alert("URLs: \n" + urls.join("\n"));
+  DocumentApp.getUi().alert("URLs: \n" + _.uniq(urls).join("\n"));
 }
 
 function replaceUrls() {
@@ -250,6 +250,14 @@ function hyperize(onlyGrabUrls) {
                 changingHyperObjects[link.url].push({"value": responseValue, "to_text": false, "link": link});
               }
             }
+            // We get here if neither the hyper label or image label were found in the response
+            else {
+              errors.push("Not found in response: " + label + " (" + url + ")");
+              if (!changingHyperObjects.hasOwnProperty(link.url)) {
+                changingHyperObjects[link.url] = [];
+              }
+              changingHyperObjects[link.url].push({"value": "[Not Found]", "to_text": true, "link": link});
+            }
           }
         }
       }
@@ -388,7 +396,7 @@ function hyperize(onlyGrabUrls) {
   showHyperElements();
 
   if (errors.length > 0) {
-    DocumentApp.getUi().alert("Errors encountered: " + errors);
+    DocumentApp.getUi().alert("Errors encountered: \n" + _.uniq(errors).join("\n"));
   }
 }
 


### PR DESCRIPTION
In this PR:
- Fix #21 by using arrays of hyper objects as values rather than single hyper objects (to avoid overwrites).
- Add a drop-down command to grab all hyper URLs in the document and prompt the user with them.
- Add a drop-down to let the user find and replace the URLs of hyper links.
